### PR TITLE
Add accept-encoding header - fixing "403 Forbidden"

### DIFF
--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -38,7 +38,7 @@ module Cleverbot
     base_uri 'http://www.cleverbot.com'
 
     parser Parser
-    headers 'Accept-Encoding' => 'x-gzip'
+    headers 'Accept-Encoding' => 'gzip'
 
     # Holds the parameters for an instantiated Client.
     attr_reader :params


### PR DESCRIPTION
This fixes 403 Forbidden responses for me.

``` ruby
{"message"=>"<html>",
 "sessionid"=>"\n<head><title>403 Forbidden</title></head>",
 "logurl"=>"\n<body bgcolor=\"white\">",
 "vText8"=>"\n<center><h1>403 Forbidden</h1></center>",
 "vText7"=>"\n<hr><center>nginx/0.7.67</center>",
 "vText6"=>"\n</body>",
 "vText5"=>"\n</html>",
 "vText4"=>"\n",
 "vText3"=>nil,
 "vText2"=>nil,
 "prevref"=>nil,
 nil=>nil,
 "emotionalhistory"=>nil,
 "ttsLocMP3"=>nil,
 "ttsLocTXT"=>nil,
 "ttsLocTXT3"=>nil,
 "ttsText"=>nil,
 "lineref"=>nil,
 "lineURL"=>nil,
 "linePOST"=>nil,
 "lineChoices"=>nil,
 "lineChoicesAbbrev"=>nil,
 "typingData"=>nil,
 "divert"=>nil}
```
