### PR TITLE
this fixes the exception raised on ruby 2.2

### DIFF
--- a/lib/cleverbot.rb
+++ b/lib/cleverbot.rb
@@ -1,4 +1,4 @@
-require 'cleverbot/client'
+require_relative './cleverbot/client'
 
 # Module enclosing all Cleverbot related classes.
 module Cleverbot

--- a/lib/cleverbot/client.rb
+++ b/lib/cleverbot/client.rb
@@ -1,4 +1,4 @@
-require 'cleverbot/parser'
+require_relative './parser'
 
 module Cleverbot
   # Ruby wrapper for Cleverbot.com.


### PR DESCRIPTION
Exception is 

```
bougyman@zaphod ~/g/clever % pry -r cleverbot
[1] pry(main)> c = Cleverbot::Client.new
=> #<Cleverbot::Client:0x9d85d84 @params={}>
[2] pry(main)> c.write "foo"
Zlib::DataError: incorrect header check
from /home/bougyman/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/net/http/response.rb:377:in `inflate'
```
